### PR TITLE
Add NehallBaig as code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @NehallBaig


### PR DESCRIPTION
This repository, created for automation training purposes, is under the guidance of NehallBaig as the sole trainer. Adding NehallBaig as a code owner for all files ensures that changes made to the repository undergo thorough review and approval by the trainer before they are merged. This approach upholds the educational standards and ensures that contributions align with the training curriculum as established by the trainer.